### PR TITLE
Cache the stride

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "micro_ndarray"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "criterion",
  "ndarray",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "micro_ndarray"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 repository = "https://github.com/tudbut/micro_ndarray"
 license = "MIT"

--- a/src/array.rs
+++ b/src/array.rs
@@ -127,9 +127,7 @@ impl<'a, T, const D: usize> Array<T, D> {
                 real_loc += dim;
                 continue;
             }
-            for s in &self.size[0..i] {
-                dim *= s;
-            }
+            dim *= self.stride[i];
             real_loc += dim;
         }
         self.data.get_unchecked(real_loc)
@@ -177,9 +175,7 @@ impl<'a, T, const D: usize> Array<T, D> {
                 real_loc += dim;
                 continue;
             }
-            for s in &self.size[0..i] {
-                dim *= s;
-            }
+            dim *= self.stride[i];
             real_loc += dim;
         }
         self.data.get_unchecked_mut(real_loc)

--- a/src/array.rs
+++ b/src/array.rs
@@ -17,8 +17,8 @@ impl<T: Default + Clone, const D: usize> Array<T, D> {
         let mut l = 1;
         let mut stride = [0usize; D];
         for (i, dim) in size.into_iter().enumerate() {
-            l *= dim;
             stride[i] = l;
+            l *= dim;
         }
         Self {
             size,
@@ -33,8 +33,8 @@ impl<T: Default + Clone, const D: usize> Array<T, D> {
         let mut l = 1;
         let mut stride = [0usize; D];
         for (i, dim) in size.into_iter().enumerate() {
-            l *= dim;
             stride[i] = l;
+            l *= dim;
         }
         Self {
             size,
@@ -49,8 +49,8 @@ impl<'a, T, const D: usize> Array<T, D> {
         let mut l = 1;
         let mut stride = [0usize; D];
         for (i, dim) in size.into_iter().enumerate() {
-            l *= dim;
             stride[i] = l;
+            l *= dim;
         }
         let mut r = Self {
             size,
@@ -67,8 +67,8 @@ impl<'a, T, const D: usize> Array<T, D> {
         let mut l = 1;
         let mut stride = [0usize; D];
         for (i, dim) in size.into_iter().enumerate() {
-            l *= dim;
             stride[i] = l;
+            l *= dim;
         }
         let mut r = Self {
             size,


### PR DESCRIPTION
It's better to cache the stride to make `get` faster.

This is a simple proof, which should be thoroughly reviewed and tested before being merged.