### PR TITLE
Optimize Vec allocation

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -45,7 +45,7 @@ impl<'a, T, const D: usize> Array<T, D> {
         }
         let mut r = Self {
             size,
-            data: Vec::new(),
+            data: Vec::with_capacity(l),
         };
         for _ in 0..l {
             r.data.push(supplier());
@@ -60,7 +60,7 @@ impl<'a, T, const D: usize> Array<T, D> {
         }
         let mut r = Self {
             size,
-            data: Vec::new(),
+            data: Vec::with_capacity(l),
         };
         for i in 0..l {
             r.data.push(supplier(i));


### PR DESCRIPTION
By passing in a capacity value, avoid performance degradation caused by multiple expansions during `.push()`.